### PR TITLE
Fix flaky test

### DIFF
--- a/Tests/HammerTests/WaitingTests.swift
+++ b/Tests/HammerTests/WaitingTests.swift
@@ -58,7 +58,7 @@ final class WaitingTests: XCTestCase {
         let eventGenerator = try EventGenerator(view: scrollView)
         try eventGenerator.waitUntilHittable(timeout: 1)
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
             scrollView.scrollRectToVisible(view.frame, animated: false)
         }
 


### PR DESCRIPTION
There was a race condition because this delay had the wrong number. Updating the value to match the other similar tests