### PR TITLE
Improve hit test methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,22 @@ When running on a full screen app or testing navigation, specifying a CGPoint in
 
 ```swift
 let myButton = try eventGenerator.viewWithIdentifier("my_button", ofType: UIButton.self)
+try eventGenerator.fingerTap(at: myButton)
 ```
 
 This method will throw an error if the view was not found in the hierarchy. If you're testing navigation or screen changes and you need to wait until the view appears, you can add a timeout. This will wait until the hierarchy has updated and return the view.
 
 ```swift
 let myButton = try eventGenerator.viewWithIdentifier("my_button", ofType: UIButton.self, timeout: 1)
+try eventGenerator.fingerTap(at: myButton)
+```
+
+You can also pass accessibility identifiers directly to the event methods.
+
+```swift
+try eventGenerator.fingerDown(at: "my_draggable_object")
+try eventGenerator.fingerMove(to: "drop_target", duration: 0.5)
+try eventGenerator.fingerUp()
 ```
 
 ### Waiting

--- a/Sources/Hammer/AppleInternal/AppleInternal+UIKit.swift
+++ b/Sources/Hammer/AppleInternal/AppleInternal+UIKit.swift
@@ -17,14 +17,14 @@ import UIKit
 extension UIApplication {
     typealias HIDEventCallback = (_ event: IOHIDEvent) -> Void
 
-    private static var hidEventCallbacks = [HIDEventCallback]()
+    private static var hidEventCallbacks = [ObjectIdentifier: HIDEventCallback]()
 
     @objc
     private func swizzledHandleHIDEvent(_ event: IOHIDEvent) {
         // Calling this really calls the original un-swizzled method
         self.swizzledHandleHIDEvent(event)
 
-        UIApplication.hidEventCallbacks.forEach { $0(event) }
+        UIApplication.hidEventCallbacks.values.forEach { $0(event) }
     }
 
     private static let runOnce: () = {
@@ -46,7 +46,11 @@ extension UIApplication {
         self.runOnce
     }
 
-    static func registerForHIDEvents(callback: @escaping HIDEventCallback) {
-        self.hidEventCallbacks.append(callback)
+    static func registerForHIDEvents(_ object: ObjectIdentifier, callback: @escaping HIDEventCallback) {
+        self.hidEventCallbacks.updateValue(callback, forKey: object)
+    }
+
+    static func unregisterForHIDEvents(_ object: ObjectIdentifier) {
+        self.hidEventCallbacks.removeValue(forKey: object)
     }
 }

--- a/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
@@ -24,7 +24,7 @@ extension EventGenerator {
     /// - parameter locations: The locations where to touch down.
     public func fingerDown(_ indices: [FingerIndex?] = .automatic, at locations: [HammerLocatable]) throws {
         let indices = try self.fillNextFingerIndices(indices, withExpected: locations.count)
-        let locations = try locations.map { try $0.hitPoint(for: self) }
+        let locations = try locations.map { try $0.screenHitPoint(for: self) }
         try self.checkPointsAreHittable(locations)
         try self.sendEvent(hand: HandInfo(fingers: zip(locations, indices).map { location, index in
             FingerInfo(fingerIndex: index, location: location, phase: .began,
@@ -37,7 +37,7 @@ extension EventGenerator {
     /// - parameter index:    The finger index to touch down.
     /// - parameter location: The location where to touch down. Nil to use the center.
     public func fingerDown(_ index: FingerIndex? = .automatic, at location: HammerLocatable? = nil) throws {
-        try self.fingerDown([index], at: [location ?? self.defaultTouchLocation])
+        try self.fingerDown([index], at: [location ?? self.mainView])
     }
 
     /// Sends a finger up event.
@@ -119,7 +119,7 @@ extension EventGenerator {
     /// - parameter locations: The new locations of the fingers.
     public func fingerMove(_ indices: [FingerIndex?] = .automatic, to locations: [HammerLocatable]) throws {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: locations.count)
-        let locations = try locations.map { try $0.hitPoint(for: self) }
+        let locations = try locations.map { try $0.screenHitPoint(for: self) }
         let fingers = zip(locations, indices).map { location, index in
             FingerInfo(fingerIndex: index, location: location, phase: .moved,
                        pressure: 0, twist: 0, majorRadius: kDefaultRadius, minorRadius: kDefaultRadius)
@@ -154,7 +154,7 @@ extension EventGenerator {
         }
 
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: locations.count)
-        let locations = try locations.map { try $0.hitPoint(for: self) }
+        let locations = try locations.map { try $0.screenHitPoint(for: self) }
         let startLocations = self.activeTouches.fingers(forIndices: indices).map(\.location)
 
         let startTime = Date()
@@ -217,7 +217,7 @@ extension EventGenerator {
                               angle radians: CGFloat = 0) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try location?.hitPoint(for: self) ?? self.defaultTouchLocation
+        let location = try (location ?? self.mainView).screenHitPoint(for: self)
         try self.fingerDown(indices, at: location.twoWayOffset(distance, angle: radians))
     }
 
@@ -245,7 +245,7 @@ extension EventGenerator {
                               angle radians: CGFloat = 0) throws
     {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 2)
-        let location = try location.hitPoint(for: self)
+        let location = try location.screenHitPoint(for: self)
         try self.fingerMove(indices, to: location.twoWayOffset(distance, angle: radians))
     }
 
@@ -263,7 +263,7 @@ extension EventGenerator {
                               withDistance distance: CGFloat = EventGenerator.twoFingerDistance,
                               angle radians: CGFloat = 0, duration: TimeInterval) throws
     {
-        let location = try location.hitPoint(for: self)
+        let location = try location.screenHitPoint(for: self)
         try self.fingerMove(indices, to: location.twoWayOffset(distance, angle: radians), duration: duration)
     }
 
@@ -300,7 +300,7 @@ extension EventGenerator {
                             angle radians: CGFloat = 0, duration: TimeInterval) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try location?.hitPoint(for: self) ?? self.defaultTouchLocation
+        let location = try (location ?? self.mainView).screenHitPoint(for: self)
         let startLocations = location.twoWayOffset(startDistance, angle: radians)
         let endLocations = location.twoWayOffset(endDistance, angle: radians)
         try self.fingerDown(indices, at: startLocations)
@@ -352,7 +352,7 @@ extension EventGenerator {
                             angle radians: CGFloat) throws
     {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 1)
-        let anchor = try anchor.hitPoint(for: self)
+        let anchor = try anchor.screenHitPoint(for: self)
         let locations = self.activeTouches.fingers(forIndices: indices).map(\.location)
         try self.fingerMove(indices, to: locations.map { $0.pivot(anchor: anchor, angle: radians) })
     }
@@ -376,7 +376,7 @@ extension EventGenerator {
         }
 
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 1)
-        let anchor = try anchor.hitPoint(for: self)
+        let anchor = try anchor.screenHitPoint(for: self)
         let startLocations = self.activeTouches.fingers(forIndices: indices).map(\.location)
 
         let startTime = Date()
@@ -413,7 +413,7 @@ extension EventGenerator {
                              duration: TimeInterval) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try location?.hitPoint(for: self) ?? self.defaultTouchLocation
+        let location = try (location ?? self.mainView).screenHitPoint(for: self)
         try self.fingerDown(indices, at: location.twoWayOffset(distance, angle: startRadians))
         try self.fingerPivot(indices, aroundAnchor: location, byAngle: endRadians - startRadians,
                              duration: duration)

--- a/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
@@ -24,7 +24,7 @@ extension EventGenerator {
     /// - parameter locations: The locations where to touch down.
     public func fingerDown(_ indices: [FingerIndex?] = .automatic, at locations: [HammerLocatable]) throws {
         let indices = try self.fillNextFingerIndices(indices, withExpected: locations.count)
-        let locations = try locations.map { try $0.screenHitPoint(for: self) }
+        let locations = try locations.map { try $0.windowHitPoint(for: self) }
         try self.checkPointsAreHittable(locations)
         try self.sendEvent(hand: HandInfo(fingers: zip(locations, indices).map { location, index in
             FingerInfo(fingerIndex: index, location: location, phase: .began,
@@ -119,7 +119,7 @@ extension EventGenerator {
     /// - parameter locations: The new locations of the fingers.
     public func fingerMove(_ indices: [FingerIndex?] = .automatic, to locations: [HammerLocatable]) throws {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: locations.count)
-        let locations = try locations.map { try $0.screenHitPoint(for: self) }
+        let locations = try locations.map { try $0.windowHitPoint(for: self) }
         let fingers = zip(locations, indices).map { location, index in
             FingerInfo(fingerIndex: index, location: location, phase: .moved,
                        pressure: 0, twist: 0, majorRadius: kDefaultRadius, minorRadius: kDefaultRadius)
@@ -154,7 +154,7 @@ extension EventGenerator {
         }
 
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: locations.count)
-        let locations = try locations.map { try $0.screenHitPoint(for: self) }
+        let locations = try locations.map { try $0.windowHitPoint(for: self) }
         let startLocations = self.activeTouches.fingers(forIndices: indices).map(\.location)
 
         let startTime = Date()
@@ -217,7 +217,7 @@ extension EventGenerator {
                               angle radians: CGFloat = 0) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try (location ?? self.mainView).screenHitPoint(for: self)
+        let location = try (location ?? self.mainView).windowHitPoint(for: self)
         try self.fingerDown(indices, at: location.twoWayOffset(distance, angle: radians))
     }
 
@@ -245,7 +245,7 @@ extension EventGenerator {
                               angle radians: CGFloat = 0) throws
     {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 2)
-        let location = try location.screenHitPoint(for: self)
+        let location = try location.windowHitPoint(for: self)
         try self.fingerMove(indices, to: location.twoWayOffset(distance, angle: radians))
     }
 
@@ -263,7 +263,7 @@ extension EventGenerator {
                               withDistance distance: CGFloat = EventGenerator.twoFingerDistance,
                               angle radians: CGFloat = 0, duration: TimeInterval) throws
     {
-        let location = try location.screenHitPoint(for: self)
+        let location = try location.windowHitPoint(for: self)
         try self.fingerMove(indices, to: location.twoWayOffset(distance, angle: radians), duration: duration)
     }
 
@@ -300,7 +300,7 @@ extension EventGenerator {
                             angle radians: CGFloat = 0, duration: TimeInterval) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try (location ?? self.mainView).screenHitPoint(for: self)
+        let location = try (location ?? self.mainView).windowHitPoint(for: self)
         let startLocations = location.twoWayOffset(startDistance, angle: radians)
         let endLocations = location.twoWayOffset(endDistance, angle: radians)
         try self.fingerDown(indices, at: startLocations)
@@ -352,7 +352,7 @@ extension EventGenerator {
                             angle radians: CGFloat) throws
     {
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 1)
-        let anchor = try anchor.screenHitPoint(for: self)
+        let anchor = try anchor.windowHitPoint(for: self)
         let locations = self.activeTouches.fingers(forIndices: indices).map(\.location)
         try self.fingerMove(indices, to: locations.map { $0.pivot(anchor: anchor, angle: radians) })
     }
@@ -376,7 +376,7 @@ extension EventGenerator {
         }
 
         let indices = try self.fillExistingFingerIndices(indices, withMinimum: 1)
-        let anchor = try anchor.screenHitPoint(for: self)
+        let anchor = try anchor.windowHitPoint(for: self)
         let startLocations = self.activeTouches.fingers(forIndices: indices).map(\.location)
 
         let startTime = Date()
@@ -413,7 +413,7 @@ extension EventGenerator {
                              duration: TimeInterval) throws
     {
         let indices = try self.fillNextFingerIndices(indices, withExpected: 2)
-        let location = try (location ?? self.mainView).screenHitPoint(for: self)
+        let location = try (location ?? self.mainView).windowHitPoint(for: self)
         try self.fingerDown(indices, at: location.twoWayOffset(distance, angle: startRadians))
         try self.fingerPivot(indices, aroundAnchor: location, byAngle: endRadians - startRadians,
                              duration: duration)

--- a/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
@@ -16,7 +16,7 @@ extension EventGenerator {
     public func stylusDown(at location: HammerLocatable? = nil,
                            azimuth: CGFloat = 0, altitude: CGFloat = 0, pressure: CGFloat = 0) throws
     {
-        let location = try (location ?? self.mainView).screenHitPoint(for: self)
+        let location = try (location ?? self.mainView).windowHitPoint(for: self)
         try self.checkPointsAreHittable([location])
         try self.sendEvent(stylus: StylusInfo(location: location, phase: .began,
                                               pressure: pressure, twist: 0,
@@ -110,7 +110,7 @@ extension EventGenerator {
     public func stylusMove(to location: HammerLocatable,
                            azimuth: CGFloat = 0, altitude: CGFloat = 0, pressure: CGFloat = 0) throws
     {
-        let location = try location.screenHitPoint(for: self)
+        let location = try location.windowHitPoint(for: self)
         try self.sendEvent(stylus: StylusInfo(location: location, phase: .moved, pressure: pressure, twist: 0,
                                               altitude: altitude, azimuth: azimuth))
     }
@@ -130,7 +130,7 @@ extension EventGenerator {
             throw HammerError.touchForStylusDoesNotExist
         }
 
-        let location = try location.screenHitPoint(for: self)
+        let location = try location.windowHitPoint(for: self)
 
         let startLocation = existingStylus.location
         let startAzimuth = existingStylus.azimuth

--- a/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
@@ -16,7 +16,7 @@ extension EventGenerator {
     public func stylusDown(at location: HammerLocatable? = nil,
                            azimuth: CGFloat = 0, altitude: CGFloat = 0, pressure: CGFloat = 0) throws
     {
-        let location = try location?.hitPoint(for: self) ?? self.defaultTouchLocation
+        let location = try (location ?? self.mainView).screenHitPoint(for: self)
         try self.checkPointsAreHittable([location])
         try self.sendEvent(stylus: StylusInfo(location: location, phase: .began,
                                               pressure: pressure, twist: 0,
@@ -110,7 +110,7 @@ extension EventGenerator {
     public func stylusMove(to location: HammerLocatable,
                            azimuth: CGFloat = 0, altitude: CGFloat = 0, pressure: CGFloat = 0) throws
     {
-        let location = try location.hitPoint(for: self)
+        let location = try location.screenHitPoint(for: self)
         try self.sendEvent(stylus: StylusInfo(location: location, phase: .moved, pressure: pressure, twist: 0,
                                               altitude: altitude, azimuth: azimuth))
     }
@@ -130,7 +130,7 @@ extension EventGenerator {
             throw HammerError.touchForStylusDoesNotExist
         }
 
-        let location = try location.hitPoint(for: self)
+        let location = try location.screenHitPoint(for: self)
 
         let startLocation = existingStylus.location
         let startAzimuth = existingStylus.azimuth

--- a/Sources/Hammer/EventGenerator/HammerLocatable.swift
+++ b/Sources/Hammer/EventGenerator/HammerLocatable.swift
@@ -1,35 +1,35 @@
 import UIKit
 
 public protocol HammerLocatable {
-    func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint
+    func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint
 }
 
 extension CGPoint: HammerLocatable {
-    public func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
         return self
     }
 }
 
 extension CGRect: HammerLocatable {
-    public func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
         return self.center
     }
 }
 
 extension UIView: HammerLocatable {
-    public func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try eventGenerator.hitPoint(forView: self)
+    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try eventGenerator.screenHitPoint(forView: self)
     }
 }
 
 extension UIViewController: HammerLocatable {
-    public func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try self.view.hitPoint(for: eventGenerator)
+    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try self.view.screenHitPoint(for: eventGenerator)
     }
 }
 
 extension String: HammerLocatable {
-    public func hitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try eventGenerator.viewWithIdentifier(self).hitPoint(for: eventGenerator)
+    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try eventGenerator.viewWithIdentifier(self).screenHitPoint(for: eventGenerator)
     }
 }

--- a/Sources/Hammer/EventGenerator/HammerLocatable.swift
+++ b/Sources/Hammer/EventGenerator/HammerLocatable.swift
@@ -1,35 +1,35 @@
 import UIKit
 
 public protocol HammerLocatable {
-    func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint
+    func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint
 }
 
 extension CGPoint: HammerLocatable {
-    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+    public func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
         return self
     }
 }
 
 extension CGRect: HammerLocatable {
-    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+    public func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
         return self.center
     }
 }
 
 extension UIView: HammerLocatable {
-    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try eventGenerator.screenHitPoint(forView: self)
+    public func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try eventGenerator.windowHitPoint(forView: self)
     }
 }
 
 extension UIViewController: HammerLocatable {
-    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try self.view.screenHitPoint(for: eventGenerator)
+    public func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try self.view.windowHitPoint(for: eventGenerator)
     }
 }
 
 extension String: HammerLocatable {
-    public func screenHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
-        return try eventGenerator.viewWithIdentifier(self).screenHitPoint(for: eventGenerator)
+    public func windowHitPoint(for eventGenerator: EventGenerator) throws -> CGPoint {
+        return try eventGenerator.viewWithIdentifier(self).windowHitPoint(for: eventGenerator)
     }
 }

--- a/Sources/Hammer/Utilties/Waiting.swift
+++ b/Sources/Hammer/Utilties/Waiting.swift
@@ -180,7 +180,7 @@ extension EventGenerator {
     ///
     /// - throws: An error if the point is not hittable within the specified time.
     public func waitUntilHittable(timeout: TimeInterval, checkInterval: TimeInterval = 0.1) throws {
-        try self.waitUntilExists(self.defaultTouchLocation,
-                                 timeout: timeout, checkInterval: checkInterval)
+        try self.waitUntil(self.viewIsHittable(self.mainView),
+                           timeout: timeout, checkInterval: checkInterval)
     }
 }

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -19,6 +19,69 @@ final class HandTests: XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
     }
 
+    func testButtonTapOnHidden() throws {
+        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.setContentHuggingPriority(.required, for: .vertical)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.backgroundColor = .green
+        view.isHidden = true
+
+        let expectation = XCTestExpectation(description: "View is not visible")
+
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap()
+        } catch HammerError.viewIsNotVisible {
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    }
+
+    func testButtonTapOnMinimumAlpha() throws {
+        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.setContentHuggingPriority(.required, for: .vertical)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.backgroundColor = .green
+        view.alpha = 0.0001
+
+        let expectation = XCTestExpectation(description: "View is not visible")
+
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap()
+        } catch HammerError.viewIsNotVisible {
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    }
+
+    func testButtonTapOnNonInteractive() throws {
+        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.setContentHuggingPriority(.required, for: .vertical)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.backgroundColor = .green
+        view.isUserInteractionEnabled = false
+
+        let expectation = XCTestExpectation(description: "View is not hittable")
+
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap()
+        } catch HammerError.viewIsNotHittable {
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    }
+
     func testButtonHighlight() throws {
         let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
         view.setContentHuggingPriority(.required, for: .vertical)

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -4,9 +4,7 @@ import XCTest
 
 final class HandTests: XCTestCase {
     func testButtonTap() throws {
-        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "Button Tapped")
@@ -20,78 +18,65 @@ final class HandTests: XCTestCase {
     }
 
     func testButtonTapOnHidden() throws {
-        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.backgroundColor = .green
         view.isHidden = true
 
-        let expectation = XCTestExpectation(description: "View is not visible")
-
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.wait(0.5)
 
         do {
             try eventGenerator.fingerTap()
+            XCTFail("Button should not be tappable")
         } catch HammerError.viewIsNotVisible {
-            expectation.fulfill()
+            // Success
+        } catch {
+            throw error
         }
-
-        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
     }
 
     func testButtonTapOnMinimumAlpha() throws {
-        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.backgroundColor = .green
         view.alpha = 0.0001
 
-        let expectation = XCTestExpectation(description: "View is not visible")
-
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.wait(0.5)
 
         do {
             try eventGenerator.fingerTap()
+            XCTFail("Button should not be tappable")
         } catch HammerError.viewIsNotVisible {
-            expectation.fulfill()
+            // Success
+        } catch {
+            throw error
         }
-
-        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
     }
 
     func testButtonTapOnNonInteractive() throws {
-        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.backgroundColor = .green
         view.isUserInteractionEnabled = false
-
-        let expectation = XCTestExpectation(description: "View is not hittable")
 
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.wait(0.5)
 
         do {
             try eventGenerator.fingerTap()
+            XCTFail("Button should not be tappable")
         } catch HammerError.viewIsNotHittable {
-            expectation.fulfill()
+            // Success
+        } catch {
+            throw error
         }
-
-        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
     }
 
     func testButtonTapOnNonInteractiveSuperview() throws {
-        let view = UIButton(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.accessibilityIdentifier = "my_button"
         view.backgroundColor = .green
 
-        let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 70, height: 70))
-        containerView.setContentHuggingPriority(.required, for: .vertical)
-        containerView.setContentHuggingPriority(.required, for: .horizontal)
+        let containerView = UIView().size(width: 100, height: 100)
         containerView.backgroundColor = .blue
         containerView.isUserInteractionEnabled = false
         containerView.addSubview(view)
@@ -110,9 +95,7 @@ final class HandTests: XCTestCase {
     }
 
     func testButtonHighlight() throws {
-        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIButton().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let touchDownExpectation = XCTestExpectation(description: "Button Touch Down")
@@ -135,9 +118,7 @@ final class HandTests: XCTestCase {
     }
 
     func testViewTapGesture() throws {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIView().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "Button Tapped")
@@ -153,9 +134,7 @@ final class HandTests: XCTestCase {
     }
 
     func testViewDoubleTapGesture() throws {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIView().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "Button Double Tapped")
@@ -172,9 +151,7 @@ final class HandTests: XCTestCase {
     }
 
     func testViewTwoFingerTapGesture() throws {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIView().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "Button Two Finger Tapped")
@@ -191,9 +168,7 @@ final class HandTests: XCTestCase {
     }
 
     func testViewLongPressGesture() throws {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIView().size(width: 100, height: 100)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "Button Long Pressed")
@@ -209,9 +184,7 @@ final class HandTests: XCTestCase {
     }
 
     func testViewRotationGesture() throws {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        view.setContentHuggingPriority(.required, for: .vertical)
-        view.setContentHuggingPriority(.required, for: .horizontal)
+        let view = UIView().size(width: 300, height: 300)
         view.backgroundColor = .green
 
         let expectation = XCTestExpectation(description: "View Rotated")
@@ -258,9 +231,7 @@ final class HandTests: XCTestCase {
     }
 
     func testScrollViewDrag() throws {
-        let view = PatternScrollView()
-        view.widthAnchor.constraint(equalToConstant: 300).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 300).isActive = true
+        let view = PatternScrollView().size(width: 300, height: 300)
 
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.waitUntilHittable(timeout: 1)
@@ -273,9 +244,7 @@ final class HandTests: XCTestCase {
     }
 
     func testScrollViewPinch() throws {
-        let view = PatternScrollView()
-        view.widthAnchor.constraint(equalToConstant: 300).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 300).isActive = true
+        let view = PatternScrollView().size(width: 300, height: 300)
 
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.waitUntilHittable(timeout: 1)
@@ -288,5 +257,13 @@ final class HandTests: XCTestCase {
         try eventGenerator.fingerPinchClose(duration: 1)
         try eventGenerator.wait(0.3)
         XCTAssertEqual(view.zoomScale, 1, accuracy: 0.1)
+    }
+}
+
+extension UIView {
+    fileprivate func size(width: CGFloat, height: CGFloat) -> Self {
+        self.widthAnchor.constraint(equalToConstant: width).isActive = true
+        self.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return self
     }
 }

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -82,6 +82,33 @@ final class HandTests: XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
     }
 
+    func testButtonTapOnNonInteractiveSuperview() throws {
+        let view = UIButton(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
+        view.setContentHuggingPriority(.required, for: .vertical)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.accessibilityIdentifier = "my_button"
+        view.backgroundColor = .green
+
+        let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 70, height: 70))
+        containerView.setContentHuggingPriority(.required, for: .vertical)
+        containerView.setContentHuggingPriority(.required, for: .horizontal)
+        containerView.backgroundColor = .blue
+        containerView.isUserInteractionEnabled = false
+        containerView.addSubview(view)
+
+        let eventGenerator = try EventGenerator(view: containerView)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap(at: "my_button")
+            XCTFail("Button should not be tappable")
+        } catch HammerError.viewIsNotHittable {
+            // Success
+        } catch {
+            throw error
+        }
+    }
+
     func testButtonHighlight() throws {
         let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
         view.setContentHuggingPriority(.required, for: .vertical)
@@ -258,8 +285,8 @@ final class HandTests: XCTestCase {
         try eventGenerator.fingerPinchOpen(duration: 1)
         try eventGenerator.wait(0.3)
         XCTAssertEqual(view.zoomScale, 6.9, accuracy: 1)
-        try eventGenerator.wait(0.3)
         try eventGenerator.fingerPinchClose(duration: 1)
+        try eventGenerator.wait(0.3)
         XCTAssertEqual(view.zoomScale, 1, accuracy: 0.1)
     }
 }

--- a/Tests/HammerTests/WaitingTests.swift
+++ b/Tests/HammerTests/WaitingTests.swift
@@ -117,7 +117,7 @@ final class WaitingTests: XCTestCase {
         let expectation = XCTestExpectation(description: "View is not found")
 
         do {
-            let _ = try eventGenerator.viewWithIdentifier("my_other_button", ofType: UIButton.self)
+            _ = try eventGenerator.viewWithIdentifier("my_other_button", ofType: UIButton.self)
         } catch HammerError.unableToFindView(let identifier) {
             XCTAssertEqual(identifier, "my_other_button")
             expectation.fulfill()

--- a/Tests/HammerTests/WaitingTests.swift
+++ b/Tests/HammerTests/WaitingTests.swift
@@ -103,4 +103,26 @@ final class WaitingTests: XCTestCase {
         let button = try eventGenerator.viewWithIdentifier("my_button", ofType: UIButton.self, timeout: 0.1)
         XCTAssertEqual(button, view)
     }
+
+    func testViewForIdentifierWithInvalidIdentifier() throws {
+        let view = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.accessibilityIdentifier = "my_button"
+        view.setContentHuggingPriority(.required, for: .vertical)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.backgroundColor = .green
+
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.waitUntilHittable(timeout: 1)
+
+        let expectation = XCTestExpectation(description: "View is not found")
+
+        do {
+            let _ = try eventGenerator.viewWithIdentifier("my_other_button", ofType: UIButton.self)
+        } catch HammerError.unableToFindView(let identifier) {
+            XCTAssertEqual(identifier, "my_other_button")
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    }
 }


### PR DESCRIPTION
Hit testing methods were failing for views with gesture recognizers and for views that only responded to a specific type of event (example: dragging). I'm updating the `screenHitPoint` to use other methods for detecting if a view is hittable.

Additionally, I've also changed the default tap location behavior to return the main view instead of the center point of the screen. By using the view directly we can check if it's actually visible or hittable, resulting in significantly better error messages.