### PR TITLE
Make CI run on external pull requests

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push]
+on: [push, pull_request]
 jobs:
   SwiftLint:
     runs-on: ubuntu-latest

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - main
 jobs:
   SwiftLint:
     runs-on: ubuntu-latest

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - main
 jobs:
   test_ipad:
     name: Test-iPad

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
   test_ipad:
     name: Test-iPad


### PR DESCRIPTION
PRs from forks are not considered a "push" so we need to add them explicitly