### PR TITLE
don't require that the UITextEffectsWindow be key

### DIFF
--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -108,8 +108,7 @@ public final class EventGenerator {
 
     /// Returns if the window is ready to receive user interaction events
     public var isWindowReady: Bool {
-        guard UIApplication.shared.keyWindow == self.window
-                && (self.window.isKeyWindow || String(describing: type(of: self.window)) == "UITextEffectsWindow")
+        guard (UIApplication.shared.keyWindow == self.window && self.window.isKeyWindow || self.window.isTextEffectsWindow)
                 && self.window.isHidden == false
                 && self.window.isUserInteractionEnabled
                 && self.window.rootViewController?.viewIfLoaded != nil
@@ -187,5 +186,11 @@ public final class EventGenerator {
         }
 
         CFRunLoopRunInMode(.defaultMode, duration, false)
+    }
+}
+
+private extension UIWindow {
+    var isTextEffectsWindow: Bool {
+        return String(describing: type(of: self)) == "UITextEffectsWindow"
     }
 }

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -109,7 +109,7 @@ public final class EventGenerator {
     /// Returns if the window is ready to receive user interaction events
     public var isWindowReady: Bool {
         guard UIApplication.shared.keyWindow == self.window
-                && self.window.isKeyWindow
+                && (self.window.isKeyWindow || String(describing: type(of: self.window)) == "UITextEffectsWindow")
                 && self.window.isHidden == false
                 && self.window.isUserInteractionEnabled
                 && self.window.rootViewController?.viewIfLoaded != nil


### PR DESCRIPTION
Based on the discussion in https://github.com/lyft/Hammer/issues/13 about interacting with the callout bar this removes the requirement that a UITextEffectsWindow be key when creating an `EventGenerator`.

So far I’ve only tested the following:
```
let textEffectsWindow = UIApplication.textEffectsWindow // a helper that gets the UITextEffectsWindow
let eventGeneratorForTextEffectsWindow = try EventGenerator(window: textEffectsWindow)
let linkButton = try eventGeneratorForTextEffectsWindow.viewWithLabel("Link") /// a helper that gets a view by its accessibilityLabel
try eventGeneratorForTextEffectsWindow.fingerDown(at: linkButton)
try eventGeneratorForTextEffectsWindow.fingerUp()
```