### PR TITLE
Remove key window requirement for touches

### DIFF
--- a/HammerTests.podspec
+++ b/HammerTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "HammerTests"
-  spec.version       = "0.10.2"
+  spec.version       = "0.11.0"
   spec.summary       = "iOS touch and keyboard syntheis library for unit tests."
   spec.description   = "Hammer is a touch and keyboard synthesis library for emulating user interaction events. It enables new ways of triggering UI actions in unit tests, replicating a real world environment as much as possible."
   spec.homepage      = "https://github.com/lyft/Hammer"

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Hammer requires Swift 5.3 and iOS 11.0 or later.
 #### With [SwiftPM](https://swift.org/package-manager)
 
 ```swift
-.package(url: "https://github.com/lyft/Hammer.git", from: "0.10.0")
+.package(url: "https://github.com/lyft/Hammer.git", from: "0.11.0")
 ```
 
 #### With [CocoaPods](https://cocoapods.org/)
 
 ```ruby
-pod 'HammerTests', '~> 0.10.2'
+pod 'HammerTests', '~> 0.11.0'
 ```
 
 ## Setup

--- a/Sources/Hammer/AppleInternal/AppleInternal+UIKit.swift
+++ b/Sources/Hammer/AppleInternal/AppleInternal+UIKit.swift
@@ -4,9 +4,6 @@ import UIKit
 @objc protocol UIApplicationPrivate: NSObjectProtocol {
     @objc(_enqueueHIDEvent:)
     func enqueue(_ event: IOHIDEvent)
-
-    @objc(_touchesEvent)
-    var touchesEvent: UIEvent { get }
 }
 
 @objc protocol UIWindowPrivate: NSObjectProtocol {

--- a/Sources/Hammer/EventGenerator/EventGenerator+Keyboard/EventGenerator+Keyboard.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Keyboard/EventGenerator+Keyboard.swift
@@ -130,6 +130,10 @@ extension EventGenerator {
     /// - parameter key:       The keyboard key for the event.
     /// - parameter isKeyDown: If the key is currently pressed down.
     private func sendKeyboardEvent(key: KeyboardKey, isKeyDown: Bool) throws {
+        guard self.window.isKeyWindow else {
+            throw HammerError.windowIsNotKey
+        }
+
         let machTime = mach_absolute_time()
 
         let event = IOHID.shared.createKeyboardEvent(

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -108,9 +108,7 @@ public final class EventGenerator {
 
     /// Returns if the window is ready to receive user interaction events
     public var isWindowReady: Bool {
-        guard UIApplication.shared.keyWindow == self.window
-                && self.window.isKeyWindow
-                && self.window.isHidden == false
+        guard self.window.isHidden == false
                 && self.window.isUserInteractionEnabled
                 && self.window.rootViewController?.viewIfLoaded != nil
                 && self.window.rootViewController?.isBeingPresented == false

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -45,8 +45,6 @@ public final class EventGenerator {
         UIApplication.registerForHIDEvents(ObjectIdentifier(self)) { [weak self] event in
             self?.markerEventReceived(event)
         }
-
-        try self.waitUntilWindowIsReady()
     }
 
     /// Initialize an event generator for a specified UIViewController.
@@ -98,7 +96,7 @@ public final class EventGenerator {
     /// Waits until the window is ready to receive user interaction events.
     ///
     /// - parameter timeout: The maximum time to wait for the window to be ready.
-    public func waitUntilWindowIsReady(timeout: TimeInterval = 2) throws {
+    public func waitUntilWindowIsReady(timeout: TimeInterval = 3) throws {
         do {
             try self.waitUntil(self.isWindowReady, timeout: timeout)
         } catch {

--- a/Sources/Hammer/Utilties/HammerError.swift
+++ b/Sources/Hammer/Utilties/HammerError.swift
@@ -3,6 +3,7 @@ import UIKit
 /// https://github.com/lyft/Hammer#troubleshooting.
 public enum HammerError: Error {
     case windowIsNotReadyForInteraction
+    case windowIsNotKey
 
     case deviceDoesNotSupportTouches
     case deviceDoesNotSupportStylus
@@ -40,6 +41,8 @@ extension HammerError: CustomStringConvertible {
                 host application and that you have given enough time for the view to present on screen. \
                 For more troubleshooting tips see: https://github.com/lyft/Hammer#troubleshooting.
                 """
+        case .windowIsNotKey:
+            return "The window must be the key window to receive keyboard events"
         case .deviceDoesNotSupportTouches:
             return "Device does not support touches"
         case .deviceDoesNotSupportStylus:

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -11,7 +11,7 @@ final class KeyboardTests: XCTestCase {
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.waitUntilHittable(timeout: 1)
 
-        view.becomeFirstResponder()
+        try eventGenerator.fingerTap()
         XCTAssertTrue(view.isFirstResponder)
 
         XCTAssertEqual(view.text, "")
@@ -162,5 +162,21 @@ final class KeyboardTests: XCTestCase {
         XCTAssertEqual(view.text, "")
         try eventGenerator.keyType(keys)
         XCTAssertEqual(view.text, result)
+    }
+
+    func testEnsureKeyWindowError() throws {
+        let view = UITextField()
+        view.disablePredictiveBar()
+        view.autocapitalizationType = .none
+        view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.waitUntilHittable(timeout: 1)
+
+        do {
+            try eventGenerator.keyType("a")
+            XCTFail("Expected error")
+        } catch HammerError.windowIsNotKey {
+            // Success
+        }
     }
 }

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -169,6 +169,16 @@ final class KeyboardTests: XCTestCase {
         view.disablePredictiveBar()
         view.autocapitalizationType = .none
         view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.isHidden = false
+        window.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.centerYAnchor.constraint(equalTo: window.centerYAnchor),
+            view.centerXAnchor.constraint(equalTo: window.centerXAnchor),
+        ])
+        
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.waitUntilHittable(timeout: 1)
 

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -178,8 +178,8 @@ final class KeyboardTests: XCTestCase {
             view.centerYAnchor.constraint(equalTo: window.centerYAnchor),
             view.centerXAnchor.constraint(equalTo: window.centerXAnchor),
         ])
-        
-        let eventGenerator = try EventGenerator(view: view)
+
+        let eventGenerator = try EventGenerator(window: window)
         try eventGenerator.waitUntilHittable(timeout: 1)
 
         do {


### PR DESCRIPTION
Key window is an unnecessary requirement for touches so I'm moving the check only to keyboard events. In many cases, the window will become key by itself when tapped, but we don't need to enforce that.