### PR TITLE
Add view container alignment options

### DIFF
--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -10,6 +10,14 @@ private enum Storage {
 public final class EventGenerator {
     typealias CompletionHandler = () -> Void
 
+    public enum WrappingAlignment {
+        /// Expand to fill the full available space
+        case fill
+
+        /// Center inside the available space
+        case center
+    }
+
     /// The window for the events
     public let window: UIWindow
 
@@ -73,9 +81,10 @@ public final class EventGenerator {
     ///
     ///  Event Generator will temporarily create a wrapper UIWindow to send touches.
     ///
-    /// - parameter view: The view to receive events.
-    public convenience init(view: UIView) throws {
-        try self.init(viewController: UIViewController(wrapping: view))
+    /// - parameter view:      The view to receive events.
+    /// - parameter alignment: The wrapping alignment to use.
+    public convenience init(view: UIView, alignment: WrappingAlignment = .center) throws {
+        try self.init(viewController: UIViewController(wrapping: view, alignment: alignment))
         self.mainView = view
     }
 

--- a/Sources/Hammer/Utilties/UIKit+Extensions.swift
+++ b/Sources/Hammer/Utilties/UIKit+Extensions.swift
@@ -51,24 +51,28 @@ extension UIWindow {
 }
 
 extension UIViewController {
-    convenience init(wrapping view: UIView) {
+    convenience init(wrapping view: UIView, alignment: EventGenerator.WrappingAlignment) {
         self.init(nibName: nil, bundle: nil)
         view.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(view)
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: self.view.topAnchor).priority(.defaultHigh),
-            view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).priority(.defaultHigh),
-            view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor).priority(.defaultHigh),
-            view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor).priority(.defaultHigh),
-            view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
-            view.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-        ])
-    }
-}
 
-extension NSLayoutConstraint {
-    fileprivate func priority(_ priority: UILayoutPriority) -> NSLayoutConstraint {
-        self.priority = priority
-        return self
+        switch alignment {
+        case .fill:
+            NSLayoutConstraint.activate([
+                view.topAnchor.constraint(equalTo: self.view.topAnchor),
+                view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+                view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            ])
+        case .center:
+            NSLayoutConstraint.activate([
+                view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+                view.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                view.topAnchor.constraint(greaterThanOrEqualTo: self.view.topAnchor),
+                view.bottomAnchor.constraint(lessThanOrEqualTo: self.view.bottomAnchor),
+                view.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor),
+                view.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor),
+            ])
+        }
     }
 }

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -109,8 +109,10 @@ final class HandTests: XCTestCase {
 
         XCTAssertFalse(view.isHighlighted)
         try eventGenerator.fingerDown()
+        try eventGenerator.wait(0.1)
         XCTAssertTrue(view.isHighlighted)
         try eventGenerator.fingerUp()
+        try eventGenerator.wait(0.1)
         XCTAssertFalse(view.isHighlighted)
 
         XCTAssertEqual(XCTWaiter.wait(for: [touchDownExpectation, touchUpExpectation], timeout: 1),

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -109,10 +109,10 @@ final class HandTests: XCTestCase {
 
         XCTAssertFalse(view.isHighlighted)
         try eventGenerator.fingerDown()
-        try eventGenerator.wait(0.1)
+        try eventGenerator.wait(0.3)
         XCTAssertTrue(view.isHighlighted)
         try eventGenerator.fingerUp()
-        try eventGenerator.wait(0.1)
+        try eventGenerator.wait(0.2)
         XCTAssertFalse(view.isHighlighted)
 
         XCTAssertEqual(XCTWaiter.wait(for: [touchDownExpectation, touchUpExpectation], timeout: 1),

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -152,6 +152,7 @@ final class KeyboardTests: XCTestCase {
         let view = UITextView()
         view.disablePredictiveBar()
         view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 300).isActive = true
         view.autocapitalizationType = .none
         let eventGenerator = try EventGenerator(view: view)
         try eventGenerator.waitUntilHittable(timeout: 1)


### PR DESCRIPTION
Previous behavior tries to support all uses but ended up being confusing and resulting in unexpected layouts. Adding the option to make the view fill or center.