### PR TITLE
Improve waiting methods

### DIFF
--- a/HammerTests.podspec
+++ b/HammerTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "HammerTests"
-  spec.version       = "0.12.0"
+  spec.version       = "0.13.0"
   spec.summary       = "iOS touch and keyboard syntheis library for unit tests."
   spec.description   = "Hammer is a touch and keyboard synthesis library for emulating user interaction events. It enables new ways of triggering UI actions in unit tests, replicating a real world environment as much as possible."
   spec.homepage      = "https://github.com/lyft/Hammer"

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Hammer requires Swift 5.3 and iOS 11.0 or later.
 #### With [SwiftPM](https://swift.org/package-manager)
 
 ```swift
-.package(url: "https://github.com/lyft/Hammer.git", from: "0.12.0")
+.package(url: "https://github.com/lyft/Hammer.git", from: "0.13.0")
 ```
 
 #### With [CocoaPods](https://cocoapods.org/)
 
 ```ruby
-pod 'HammerTests', '~> 0.12.0'
+pod 'HammerTests', '~> 0.13.0'
 ```
 
 ## Setup

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -178,8 +178,8 @@ public final class EventGenerator {
 
     /// Sleeps the current thread until the events have finished sending.
     private func waitForEvents() throws {
-        let runLoop = CFRunLoopGetCurrent()
-        try self.sendMarkerEvent { CFRunLoopStop(runLoop) }
-        CFRunLoopRun()
+        let waiter = Waiter(timeout: 1)
+        try self.sendMarkerEvent { try? waiter.complete() }
+        try waiter.start()
     }
 }

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -54,7 +54,7 @@ public final class EventGenerator {
             self?.markerEventReceived(event)
         }
 
-        self.waitUntilWindowIsReady()
+        try self.waitUntilWindowIsReady()
     }
 
     /// Initialize an event generator for a specified UIViewController.

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -53,6 +53,8 @@ public final class EventGenerator {
         UIApplication.registerForHIDEvents(ObjectIdentifier(self)) { [weak self] event in
             self?.markerEventReceived(event)
         }
+
+        self.waitUntilWindowIsReady()
     }
 
     /// Initialize an event generator for a specified UIViewController.

--- a/Sources/Hammer/Utilties/HammerError.swift
+++ b/Sources/Hammer/Utilties/HammerError.swift
@@ -30,6 +30,10 @@ public enum HammerError: Error {
     case unableToFindView(identifier: String)
     case invalidViewType(identifier: String, type: String, expected: String)
     case waitConditionTimeout(TimeInterval)
+
+    case waiterIsNotRunning
+    case waiterIsAlreadyRunning
+    case waiterIsAlreadyCompleted
 }
 
 extension HammerError: CustomStringConvertible {
@@ -79,6 +83,12 @@ extension HammerError: CustomStringConvertible {
             return "Invalid type for view: \"\(identifier)\", got \"\(type)\" expected \"\(expected)\""
         case .waitConditionTimeout(let timeout):
             return "Timeout while waiting for condition exceeded \(timeout) seconds"
+        case .waiterIsNotRunning:
+            return "Unable to stop a Waiter that is not running"
+        case .waiterIsAlreadyRunning:
+            return "Unable to start a Waiter that is already running"
+        case .waiterIsAlreadyCompleted:
+            return "Unable to start or stop a waiter that is already completed"
         }
     }
 }

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -171,14 +171,17 @@ final class KeyboardTests: XCTestCase {
         view.autocapitalizationType = .none
         view.widthAnchor.constraint(equalToConstant: 300).isActive = true
 
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        window.isHidden = false
-        window.addSubview(view)
+        let viewController = UIViewController()
+        viewController.view.addSubview(view)
         view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            view.centerYAnchor.constraint(equalTo: window.centerYAnchor),
-            view.centerXAnchor.constraint(equalTo: window.centerXAnchor),
+            view.centerYAnchor.constraint(equalTo: viewController.view.centerYAnchor),
+            view.centerXAnchor.constraint(equalTo: viewController.view.centerXAnchor),
         ])
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.isHidden = false
 
         let eventGenerator = try EventGenerator(window: window)
         try eventGenerator.waitUntilHittable(timeout: 1)

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,8 @@ targets:
     platform: iOS
     deploymentTarget: "11.0"
     sources: Sources/Hammer
+    settings:
+      ENABLE_TESTING_SEARCH_PATHS: true
     scheme:
       testTargets:
         - HammerTests


### PR DESCRIPTION
There were some problems using the runloop for waiting because it could block the events from being processed too. I looked into alternatives to drain the runloop, but when I tested with using XCTestWaiter everything worked great with much less complexity.

Wrapped it in a new Waiter object so that we can easily replace the internal implementation in the future.