### PR TITLE
Silence unhandled resources warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,10 @@ let package = Package(
         .library(name: "Hammer", targets: ["Hammer"]),
     ],
     targets: [
-        .target(name: "Hammer"),
-
+        .target(
+          name: "Hammer",
+          exclude: ["Info.plist"]
+        ),
         // Disabled because SPM does not support running on TestHost yet
         // .testTarget(name: "HammerTests", dependencies: ["Hammer"]),
     ]


### PR DESCRIPTION
This PR silences the Xcode warning as below caused by Info.plist file. 
FYI) I'm running Xcode 12.5.1

<img width="915" alt="Screen Shot 2021-07-30 at 2 24 53 PM" src="https://user-images.githubusercontent.com/3890050/127605354-9b313822-8270-4bca-91cc-acd4aaee4d6d.png">
