### PR TITLE
Improve scrolling flaky test

### DIFF
--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -242,7 +242,7 @@ final class HandTests: XCTestCase {
         try eventGenerator.fingerDrag(from: view.frame.center.offset(x: 40, y: 100),
                                       to: view.frame.center.offset(x: -40, y: -100),
                                       duration: 1)
-        XCTAssertEqual(view.contentOffset, CGPoint(x: 75, y: 190), accuracy: 2)
+        XCTAssertEqual(view.contentOffset, CGPoint(x: 75, y: 190), accuracy: 10)
     }
 
     func testScrollViewPinch() throws {


### PR DESCRIPTION
ScrollViews seem to be a little inconsistent when they start scrolling. The gesture detection requires a few points of travel to begin detecting, but the exact time the detection begins seems to vary, meaning that the scroll amount is not precise. Fixing by making the check allow for a bigger variation