### PR TITLE
Improve readiness checks

### DIFF
--- a/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
@@ -25,7 +25,6 @@ extension EventGenerator {
     public func fingerDown(_ indices: [FingerIndex?] = .automatic, at locations: [HammerLocatable]) throws {
         let indices = try self.fillNextFingerIndices(indices, withExpected: locations.count)
         let locations = try locations.map { try $0.windowHitPoint(for: self) }
-        try self.checkPointsAreHittable(locations)
         try self.sendEvent(hand: HandInfo(fingers: zip(locations, indices).map { location, index in
             FingerInfo(fingerIndex: index, location: location, phase: .began,
                        pressure: 0, twist: 0, majorRadius: kDefaultRadius, minorRadius: kDefaultRadius)
@@ -443,6 +442,8 @@ extension EventGenerator {
     ///
     /// - parameter hand: The event to send.
     private func sendEvent(hand: HandInfo) throws {
+        try checkPointsAreHittable(hand.fingers.map(\.location))
+
         let machTime = mach_absolute_time()
         let isTouching = hand.isTouching
 

--- a/Sources/Hammer/EventGenerator/EventGenerator+Keyboard/EventGenerator+Keyboard.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Keyboard/EventGenerator+Keyboard.swift
@@ -130,6 +130,10 @@ extension EventGenerator {
     /// - parameter key:       The keyboard key for the event.
     /// - parameter isKeyDown: If the key is currently pressed down.
     private func sendKeyboardEvent(key: KeyboardKey, isKeyDown: Bool) throws {
+        guard self.isWindowReady else {
+            throw HammerError.windowIsNotReadyForInteraction
+        }
+
         guard self.window.isKeyWindow else {
             throw HammerError.windowIsNotKey
         }

--- a/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Stylus/EventGenerator+Stylus.swift
@@ -17,7 +17,6 @@ extension EventGenerator {
                            azimuth: CGFloat = 0, altitude: CGFloat = 0, pressure: CGFloat = 0) throws
     {
         let location = try (location ?? self.mainView).windowHitPoint(for: self)
-        try self.checkPointsAreHittable([location])
         try self.sendEvent(stylus: StylusInfo(location: location, phase: .began,
                                               pressure: pressure, twist: 0,
                                               altitude: altitude, azimuth: azimuth))
@@ -163,6 +162,8 @@ extension EventGenerator {
     ///
     /// - parameter stylus: The event to send.
     private func sendEvent(stylus: StylusInfo) throws {
+        try self.checkPointsAreHittable([stylus.location])
+
         let machTime = mach_absolute_time()
         let isTouching = stylus.phase.isTouching
 

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -117,7 +117,8 @@ public final class EventGenerator {
 
     /// Returns if the window is ready to receive user interaction events
     public var isWindowReady: Bool {
-        guard self.window.isHidden == false
+        guard !UIApplication.shared.isIgnoringInteractionEvents
+                && self.window.isHidden == false
                 && self.window.isUserInteractionEnabled
                 && self.window.rootViewController?.viewIfLoaded != nil
                 && self.window.rootViewController?.isBeingPresented == false
@@ -130,10 +131,6 @@ public final class EventGenerator {
 
         if #available(iOS 13.0, *) {
             guard self.window.windowScene?.activationState == .foregroundActive else {
-                return false
-            }
-        } else {
-            guard !UIApplication.shared.isIgnoringInteractionEvents else {
                 return false
             }
         }

--- a/Sources/Hammer/Utilties/Subviews.swift
+++ b/Sources/Hammer/Utilties/Subviews.swift
@@ -223,6 +223,10 @@ extension EventGenerator {
     ///
     /// - returns: If the view is hittable
     public func viewIsHittable(_ view: UIView, atPoint point: CGPoint? = nil) -> Bool {
+        guard self.isWindowReady else {
+            return false
+        }
+
         guard self.viewIsVisible(view) else {
             return false
         }
@@ -270,6 +274,10 @@ extension EventGenerator {
     ///
     /// - returns: If the point is hittable
     public func pointIsHittable(_ point: CGPoint) -> Bool {
+        guard self.isWindowReady else {
+            return false
+        }
+
         return self.window.hitTest(point, with: nil) != nil
     }
 
@@ -279,6 +287,10 @@ extension EventGenerator {
     ///
     /// - throws: If one of the points is not hittable
     func checkPointsAreHittable(_ points: [CGPoint]) throws {
+        guard self.isWindowReady else {
+            throw HammerError.windowIsNotReadyForInteraction
+        }
+
         for point in points {
             if !self.pointIsHittable(point) {
                 throw HammerError.pointIsNotHittable(point)
@@ -296,6 +308,10 @@ extension EventGenerator {
     public func windowHitPoint(forView view: UIView) throws -> CGPoint {
         guard view.isDescendant(of: self.window) else {
             throw HammerError.viewIsNotInHierarchy(view)
+        }
+
+        guard self.isWindowReady else {
+            throw HammerError.windowIsNotReadyForInteraction
         }
 
         guard self.viewIsVisible(view) else {


### PR DESCRIPTION
While debugging some flakiness in tests that had custom window presentation, I found that the `UIApplication.shared.isIgnoringInteractionEvents` is effective at detecting UIWindow transitions. It is marked as deprecated since iOS13 but there does not seem to be a better way to get the same information, so i've moved it as a main check for all versions.

At the same time, I added the `isWindowReady` checks in more places to output better error messages