### PR TITLE
Fix FingerUp causing UITouch to end in start location

### DIFF
--- a/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Hand/EventGenerator+Hand.swift
@@ -498,6 +498,7 @@ extension EventGenerator {
                 throw HammerError.touchForFingerDoesNotExist(index: finger.fingerIndex)
             }
 
+            try self.activeTouches.update(finger: finger, forIdentifier: existingIdentifier)
             return existingIdentifier
         case .ended, .cancelled:
             guard let existingIdentifier = existingIdentifier else {

--- a/Sources/Hammer/Utilties/TouchStorage.swift
+++ b/Sources/Hammer/Utilties/TouchStorage.swift
@@ -58,5 +58,8 @@ struct TouchStorage {
     mutating func update(finger: FingerInfo, forIdentifier identifier: UInt32) throws {
         self.fingerStore.removeAll { $0.identifier == identifier }
         self.fingerStore.append((finger, identifier))
+        if let index = self.fingerStore.firstIndex(where: { $0.identifier == identifier }) {
+            self.fingerStore[index].finger = finger
+        }
     }
 }

--- a/Sources/Hammer/Utilties/TouchStorage.swift
+++ b/Sources/Hammer/Utilties/TouchStorage.swift
@@ -54,4 +54,9 @@ struct TouchStorage {
             self.stylusStore = nil
         }
     }
+
+    mutating func update(finger: FingerInfo, forIdentifier identifier: UInt32) throws {
+        self.fingerStore.removeAll { $0.identifier == identifier }
+        self.fingerStore.append((finger, identifier))
+    }
 }

--- a/Sources/Hammer/Utilties/TouchStorage.swift
+++ b/Sources/Hammer/Utilties/TouchStorage.swift
@@ -56,8 +56,6 @@ struct TouchStorage {
     }
 
     mutating func update(finger: FingerInfo, forIdentifier identifier: UInt32) throws {
-        self.fingerStore.removeAll { $0.identifier == identifier }
-        self.fingerStore.append((finger, identifier))
         if let index = self.fingerStore.firstIndex(where: { $0.identifier == identifier }) {
             self.fingerStore[index].finger = finger
         }

--- a/Tests/HammerTests/DragTests.swift
+++ b/Tests/HammerTests/DragTests.swift
@@ -1,0 +1,24 @@
+import Hammer
+import XCTest
+import Foundation
+
+final class DragTests: XCTestCase {
+
+    func test_drag() throws {
+        let view = TouchTestView()
+
+        view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 300).isActive = true
+
+        let eventGenerator = try EventGenerator(view: view)
+        try eventGenerator.waitUntilHittable(timeout: 1)
+
+        try eventGenerator.fingerDown(at: view.frame.center.offset(x: -50, y: 0))
+        try eventGenerator.fingerMove(to: view.frame.center.offset(x: 50, y: 0), duration: 0.3)
+        try eventGenerator.fingerUp()
+
+        let endPoint = view.touches.first!.location(in: view)
+        XCTAssertEqual(endPoint, CGPoint(x: 200, y: 150), accuracy: 0.001)
+    }
+
+}

--- a/Tests/HammerTests/Utilities/TouchTestView.swift
+++ b/Tests/HammerTests/Utilities/TouchTestView.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+final class TouchTestView: UIView {
+
+  var touches: Set<UITouch> = .init()
+
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesBegan(touches, with: event)
+
+    touches.forEach { self.touches.insert($0) }
+  }
+
+}


### PR DESCRIPTION
@gabriellanata Hey buddy,

There is a a bug in fingerUp where the location in touchesEnded callback is the start position of the drag(e.g. fingerDown). It is because FingerInfo only holds the initial location of the finger, so when I call fingerUp, it will cause the final touch on the initial point, not where the drag has ended.

To reproduce, comment out [this line](https://github.com/lyft/Hammer/pull/35/files#diff-81933bc310940b48b3d40509a3f0f98176bba970434e4c646b64d0a9e78372b2R501) and run the DragTests I put in.

Once again, I greatly appreciate this library you put together. It has opened up fantastic automated testing suites for my app.