### PR TITLE
Improve visibility check

### DIFF
--- a/Sources/Hammer/Utilties/Subviews.swift
+++ b/Sources/Hammer/Utilties/Subviews.swift
@@ -168,9 +168,11 @@ extension EventGenerator {
                 return currentView == self.window
             }
 
-            let adjustedBounds = view.convert(view.bounds, to: superview)
-            guard superview.bounds.isVisible(adjustedBounds, visibility: visibility) else {
-                return false
+            if superview.clipsToBounds {
+                let adjustedBounds = view.convert(view.bounds, to: superview)
+                guard superview.bounds.isVisible(adjustedBounds, visibility: visibility) else {
+                    return false
+                }
             }
 
             return viewIsVisible(currentView: superview)

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -71,6 +71,71 @@ final class HandTests: XCTestCase {
         }
     }
 
+    func testButtonTapInsideOfBounds() throws {
+        let containerView = UIView().size(width: 100, height: 100)
+        containerView.backgroundColor = .blue
+        containerView.clipsToBounds = false
+
+        let view = UIButton().size(width: 100, height: 100)
+        view.backgroundColor = .green
+        containerView.addSubview(view)
+        view.setOrigin(x: 0, y: 0)
+
+        let expectation = XCTestExpectation(description: "Button Tapped")
+        view.addHandler(forEvent: .primaryActionTriggered, action: expectation.fulfill)
+
+        let eventGenerator = try EventGenerator(view: containerView)
+        try eventGenerator.waitUntilHittable(view, timeout: 1)
+        try eventGenerator.fingerTap(at: view)
+
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    }
+
+    func testButtonTapOutOfBounds() throws {
+        let containerView = UIView().size(width: 100, height: 100)
+        containerView.backgroundColor = .blue
+
+        let view = UIButton().size(width: 100, height: 100)
+        view.backgroundColor = .green
+        containerView.addSubview(view)
+        view.setOrigin(x: 0, y: 100)
+
+        let eventGenerator = try EventGenerator(view: containerView)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap(at: view)
+            XCTFail("Button should not be tappable")
+        } catch HammerError.viewIsNotHittable {
+            // Success
+        } catch {
+            throw error
+        }
+    }
+
+    func testButtonTapOutOfBoundsClipped() throws {
+        let containerView = UIView().size(width: 100, height: 100)
+        containerView.backgroundColor = .blue
+        containerView.clipsToBounds = true
+
+        let view = UIButton().size(width: 100, height: 100)
+        view.backgroundColor = .green
+        containerView.addSubview(view)
+        view.setOrigin(x: 0, y: 100)
+
+        let eventGenerator = try EventGenerator(view: containerView)
+        try eventGenerator.wait(0.5)
+
+        do {
+            try eventGenerator.fingerTap(at: view)
+            XCTFail("Button should not be tappable")
+        } catch HammerError.viewIsNotVisible {
+            // Success
+        } catch {
+            throw error
+        }
+    }
+
     func testButtonTapOnNonInteractiveSuperview() throws {
         let view = UIButton().size(width: 100, height: 100)
         view.accessibilityIdentifier = "my_button"
@@ -267,5 +332,15 @@ extension UIView {
         self.widthAnchor.constraint(equalToConstant: width).isActive = true
         self.heightAnchor.constraint(equalToConstant: height).isActive = true
         return self
+    }
+
+    fileprivate func setOrigin(x: CGFloat, y: CGFloat) {
+        guard let superview = self.superview else {
+            fatalError("View must be added as a subview before setting origin constraints")
+        }
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: x).isActive = true
+        self.topAnchor.constraint(equalTo: superview.topAnchor, constant: y).isActive = true
     }
 }

--- a/Tests/HammerTests/HandTests.swift
+++ b/Tests/HammerTests/HandTests.swift
@@ -2,6 +2,7 @@ import Hammer
 import UIKit
 import XCTest
 
+// swiftlint:disable:next type_body_length
 final class HandTests: XCTestCase {
     func testButtonTap() throws {
         let view = UIButton().size(width: 100, height: 100)


### PR DESCRIPTION
The visibility check was not taking into account the `clipsToBounds` property so it was often returning the wrong error (it should have passed the visibility check but not the hittable check).

Fixes #38 