### PR TITLE
Fix for Swift 5.6

### DIFF
--- a/HammerTests.podspec
+++ b/HammerTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "HammerTests"
-  spec.version       = "0.14.0"
+  spec.version       = "0.14.1"
   spec.summary       = "iOS touch and keyboard syntheis library for unit tests."
   spec.description   = "Hammer is a touch and keyboard synthesis library for emulating user interaction events. It enables new ways of triggering UI actions in unit tests, replicating a real world environment as much as possible."
   spec.homepage      = "https://github.com/lyft/Hammer"

--- a/Sources/Hammer/AppleInternal/AppleInternal+IOHID.swift
+++ b/Sources/Hammer/AppleInternal/AppleInternal+IOHID.swift
@@ -42,7 +42,7 @@ struct IOHID {
 
     typealias IOHIDEventCreateVendorDefinedEvent = @convention(c) (
         _ allocator: CFAllocator?, _ timestamp: UInt64, _ usagePage: UInt32, _ usage: UInt32,
-        _ version: UInt32, _ data: [UInt8], _ length: Int, _ options: CFOptionFlags) -> IOHIDEvent
+        _ version: UInt32, _ data: NSArray, _ length: Int, _ options: CFOptionFlags) -> IOHIDEvent
 
     typealias IOHIDEventSystemClientCreate = @convention(c) (
         _ allocator: CFAllocator?) -> IOHIDEventSystemClient

--- a/Sources/Hammer/EventGenerator/EventGenerator+Marker.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator+Marker.swift
@@ -1,5 +1,6 @@
 import CoreFoundation
 import Darwin
+import Foundation
 
 extension EventGenerator {
     func sendMarkerEvent(withCompletionBlock completion: @escaping CompletionHandler) throws {
@@ -11,7 +12,7 @@ extension EventGenerator {
             kCFAllocatorDefault, mach_absolute_time(),
             IOHID.Page.vendorDefinedStart.rawValue + 100,
             0, 1,
-            eventIdBytes, MemoryLayout.size(ofValue: eventIdBytes),
+            eventIdBytes as NSArray, MemoryLayout.size(ofValue: eventIdBytes),
             kIOHIDEventOptionNone)
 
         // NOTE: This should not be needed. It is a workaround because the previous method doesn't seem to be


### PR DESCRIPTION
There is a bug when using `@convention(c)` with bridged types in Swift 5.6: https://bugs.swift.org/browse/SR-15696. This has been fixed in the next version of swift and hopefully will be [cherry picked into 5.6.x](https://github.com/apple/swift/pull/41774). For now, we can work around this by using NSArray to avoid bridging.

Fixes #45 