### PR TITLE
Bypass deprecation warning

### DIFF
--- a/HammerTests.podspec
+++ b/HammerTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "HammerTests"
-  spec.version       = "0.14.1"
+  spec.version       = "0.14.2"
   spec.summary       = "iOS touch and keyboard syntheis library for unit tests."
   spec.description   = "Hammer is a touch and keyboard synthesis library for emulating user interaction events. It enables new ways of triggering UI actions in unit tests, replicating a real world environment as much as possible."
   spec.homepage      = "https://github.com/lyft/Hammer"

--- a/Sources/Hammer/EventGenerator/EventGenerator.swift
+++ b/Sources/Hammer/EventGenerator/EventGenerator.swift
@@ -123,7 +123,7 @@ public final class EventGenerator {
 
     /// Returns if the window is ready to receive user interaction events
     public var isWindowReady: Bool {
-        guard !UIApplication.shared.isIgnoringInteractionEvents
+        guard !(UIApplication.shared as UIApplicationDeprecated).isIgnoringInteractionEvents
                 && self.window.isHidden == false
                 && self.window.isUserInteractionEnabled
                 && self.window.rootViewController?.viewIfLoaded != nil
@@ -183,3 +183,10 @@ public final class EventGenerator {
         try waiter.start()
     }
 }
+
+// Bypasses deprecation warning for `isIgnoringInteractionEvents`
+private protocol UIApplicationDeprecated {
+    var isIgnoringInteractionEvents: Bool { get }
+}
+
+extension UIApplication: UIApplicationDeprecated {}


### PR DESCRIPTION
This method is deprecated but we still need to use it because iOS uses it itself and we need it to detect when the app is ignoring events. The fix is to add a protocol to bypass the warning.