### PR TITLE
Fix point calculation for twoWayOffset due to wrong angle direction

### DIFF
--- a/Sources/Hammer/Utilties/CoreGraphic+Extensions.swift
+++ b/Sources/Hammer/Utilties/CoreGraphic+Extensions.swift
@@ -33,7 +33,7 @@ extension CGPoint {
     func twoWayOffset(_ distance: CGFloat, angle radians: CGFloat) -> [CGPoint] {
         return [
             self.offset(distance / 2, angle: radians),
-            self.offset(distance / 2, angle: .pi - radians),
+            self.offset(distance / 2, angle: .pi + radians),
         ]
     }
 


### PR DESCRIPTION
This PR address incorrect calculation for a `twoWayOffset` function. Expected behaviour (I guess) was to have two touches with 180° with configurable angle to the horizont. 
### After PR

```swift
let angle = -35 * (Double.pi / 180.0)
try eventGenerator.fingerPinch(fromDistance: 20, toDistance: 200, angle: angle, duration: 3)
```

https://user-images.githubusercontent.com/735178/235194465-bb6c3b89-e374-4dbf-b169-a3e545d3e1b7.mov



### Before
Here is how it looks like for angle = 0:

https://user-images.githubusercontent.com/735178/235193742-400003a7-891b-4ca5-9d3b-185a79350701.mov

And this is what we have for a 35 degrees angle:


https://user-images.githubusercontent.com/735178/235193860-98d84749-9fff-4814-a43a-f4f356b8bf9e.mov

