### PR TITLE
Suppprt scenes based apps

### DIFF
--- a/Sources/Hammer/Utilties/UIKit+Extensions.swift
+++ b/Sources/Hammer/Utilties/UIKit+Extensions.swift
@@ -46,6 +46,10 @@ extension UIDevice {
 extension UIWindow {
     convenience init(wrapping viewController: UIViewController) {
         self.init(frame: UIScreen.main.bounds)
+        if #available(iOS 13.0, *), self.windowScene == nil {
+            self.windowScene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }.first
+        }
         self.rootViewController = viewController
     }
 }

--- a/TestHost/Info.plist
+++ b/TestHost/Info.plist
@@ -41,5 +41,22 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/TestHost/SceneDelegate.swift
+++ b/TestHost/SceneDelegate.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+@available(iOS 13.0, *)
+final class SceneDelegate: UIResponder, UISceneDelegate {
+    var window: UIWindow?
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {}
+}
+

--- a/TestHost/SceneDelegate.swift
+++ b/TestHost/SceneDelegate.swift
@@ -6,4 +6,3 @@ final class SceneDelegate: UIResponder, UISceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {}
 }
-

--- a/Tests/HammerTests/KeyboardTests.swift
+++ b/Tests/HammerTests/KeyboardTests.swift
@@ -1,4 +1,4 @@
-import Hammer
+@testable import Hammer
 import UIKit
 import XCTest
 
@@ -187,8 +187,7 @@ final class KeyboardTests: XCTestCase {
             view.centerXAnchor.constraint(equalTo: viewController.view.centerXAnchor),
         ])
 
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = viewController
+        let window = UIWindow(wrapping: viewController)
         window.isHidden = false
 
         let eventGenerator = try EventGenerator(window: window)


### PR DESCRIPTION
For scenes based apps (iOS 13 and higher) window scene is not set automatically, so  this check make every test fail:
```
if #available(iOS 13.0, *) {
    guard self.window.windowScene?.activationState == .foregroundActive else {
        return false
    }
}
```
This PR sets windowScene if it's not set.