### PR TITLE
Use xcbeautify for test logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ install-lint:
 install-xcodegen:
 	brew list xcodegen &>/dev/null || brew install xcodegen
 
+install-xcbeautify:
+	brew list xcbeautify &>/dev/null || brew install xcbeautify
+
 # Run Tasks
 
 generate: install-xcodegen
@@ -29,7 +32,7 @@ test-iPad:
 		-scheme Hammer \
 		-destination "name=iPad Pro (12.9-inch) (6th generation)" \
 		test \
-		$(NO_CODE_SIGN_SETTINGS)
+		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 
 test-iPhone:
 	set -o pipefail && \
@@ -38,7 +41,7 @@ test-iPhone:
 		-scheme Hammer \
 		-destination "name=iPhone 15" \
 		test \
-		$(NO_CODE_SIGN_SETTINGS)
+		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 
 test-iPhone-iOS15:
 	set -o pipefail && \
@@ -48,7 +51,7 @@ test-iPhone-iOS15:
 		-destination "name=iPhone 11" \
 		-sdk iphonesimulator15.0 \
 		test \
-		$(NO_CODE_SIGN_SETTINGS)
+		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 
 # List all targets (from https://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile)
 


### PR DESCRIPTION
[xcbeautify](https://github.com/cpisciotta/xcbeautify) comes installed in Github Actions runners so we can use that to prevent the massive xcodebuild logs.

| Before | After |
|--------|--------|
| <img width="1000" alt="image" src="https://github.com/lyft/Hammer/assets/14804033/9fa25c6a-cb88-4c6a-9cf3-6e34e38f8614"> | <img width="1000" alt="image" src="https://github.com/lyft/Hammer/assets/14804033/78a278ea-9f2b-4cbd-b40a-7c6c8eb1bd23"> |