### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Force Xcode 15.4
-        run: sudo xcode-select -switch /Applications/Xcode_15.4.app
+      - name: Force Xcode 26.0
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
       - name: Make project
         run: make generate
       - name: Run tests
@@ -23,22 +23,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Force Xcode 15.4
-        run: sudo xcode-select -switch /Applications/Xcode_15.4.app
+      - name: Force Xcode 26.0
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
       - name: Make project
         run: make generate
       - name: Run tests
         run: make test-iPhone
   test_iphone_ios16:
-    name: Test-iPhone-iOS16
-    runs-on: macos-13
+    name: Test-iPhone-iOS17
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Force Xcode 14.1
-        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
+      - name: Force Xcode 15.3
+        run: sudo xcode-select -switch /Applications/Xcode_15.3.app
       - name: Make project
         run: make generate
       - name: Run tests
-        run: make test-iPhone-iOS16
-
+        run: make test-iPhone-iOS17

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -31,7 +31,7 @@ jobs:
         run: make test-iPhone
   test_iphone_ios17:
     name: Test-iPhone-iOS17
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -29,7 +29,7 @@ jobs:
         run: make generate
       - name: Run tests
         run: make test-iPhone
-  test_iphone_ios16:
+  test_iphone_ios17:
     name: Test-iPhone-iOS17
     runs-on: macos-15
     steps:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-iPad:
 		xcodebuild \
 		-project Hammer.xcodeproj \
 		-scheme Hammer \
-		-destination "name=iPad Pro (12.9-inch) (6th generation)" \
+		-destination "name=iPad Pro 13-inch (M4)" \
 		test \
 		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 
@@ -39,17 +39,17 @@ test-iPhone:
 		xcodebuild \
 		-project Hammer.xcodeproj \
 		-scheme Hammer \
-		-destination "name=iPhone 15" \
+		-destination "name=iPhone 17" \
 		test \
 		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 
-test-iPhone-iOS16:
+test-iPhone-iOS17:
 	set -o pipefail && \
 		xcodebuild \
 		-project Hammer.xcodeproj \
 		-scheme Hammer \
-		-destination "name=iPhone 14" \
-		-sdk iphonesimulator16.1 \
+		-destination "name=iPhone 15" \
+		-sdk iphonesimulator17.1 \
 		test \
 		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-iPhone-iOS17:
 		-project Hammer.xcodeproj \
 		-scheme Hammer \
 		-destination "name=iPhone 15" \
-		-sdk iphonesimulator17.1 \
+		-sdk iphonesimulator17.4 \
 		test \
 		$(NO_CODE_SIGN_SETTINGS) | xcbeautify
 


### PR DESCRIPTION
Updating CI to remove deprecated versions. We still technically support iOS 16 but CI is having trouble with it.